### PR TITLE
Replace screenshots in chapter 6 with TikZ diagrams

### DIFF
--- a/Notes/TIKZ/determinant-algo-slow.tikz
+++ b/Notes/TIKZ/determinant-algo-slow.tikz
@@ -1,0 +1,27 @@
+
+\begin{tikzpicture}[
+  level distance=2cm,
+  level 1/.style={->, sibling distance=4cm},
+  level 2/.style={->, sibling distance=2cm},
+  every node/.style={align=center}
+]
+
+\node {$\left[\begin{array}{ccc} 3 & 7 & 5 \\ 2 & 9 & 8 \\ 1 & 3 & 3 \end{array}\right]$}
+child {
+  node {$\left[\begin{array}{cc} 3 & 8 \\ 3 & 3 \end{array}\right]$}
+  child { node {$[3]$} }
+  child { node {$[3]$} }
+}
+child {
+  node {$\left[\begin{array}{cc} 2 & 8 \\ 1 & 3 \end{array}\right]$}
+  child { node {$[3]$} }
+  child { node {$[4]$} }
+}
+child {
+  node {$\left[\begin{array}{cc} 2 & 9 \\ 1 & 3 \end{array}\right]$}
+  child { node {$[3]$} }
+  child { node {$[4]$} }
+};
+
+\end{tikzpicture}
+

--- a/Notes/TIKZ/determinant-algo-slow.tikz
+++ b/Notes/TIKZ/determinant-algo-slow.tikz
@@ -15,12 +15,12 @@ child {
 child {
   node {$\left[\begin{array}{cc} 2 & 8 \\ 1 & 3 \end{array}\right]$}
   child { node {$[3]$} }
-  child { node {$[4]$} }
+  child { node {$[1]$} }
 }
 child {
   node {$\left[\begin{array}{cc} 2 & 9 \\ 1 & 3 \end{array}\right]$}
   child { node {$[3]$} }
-  child { node {$[4]$} }
+  child { node {$[1]$} }
 };
 
 \end{tikzpicture}

--- a/Notes/TIKZ/echelon-gaussian-elimination.tikz
+++ b/Notes/TIKZ/echelon-gaussian-elimination.tikz
@@ -1,0 +1,75 @@
+\begin{tikzpicture}[scale=0.6]
+
+% Colors
+\definecolor{mypurple}{RGB}{170,110,200}
+\definecolor{myred}{RGB}{210,120,140}
+\definecolor{myblue}{RGB}{0,150,180}
+
+\definecolor{green}{RGB}{0,140,0}
+
+\draw[thick, green]
+    (2,-0.5) -- (6.3,-0.5) -- (6.3 ,1)
+    -- (6.3,1)
+    -- (6.3,1.8)
+    -- (4.8,1.8)
+    -- (4.8,2.6)
+    -- (3.3,2.6)
+    -- (3.3,3.4)
+    -- (2,3.4)
+    -- cycle;
+
+\node[green] at (3,1.2) {$0$'s only};
+
+\draw[thick, myblue]
+    (2,4.2)
+    -- (6.3 ,4.2)
+    -- (6.3,2)
+    -- (5,2)
+    -- (5,2.8)
+    -- (3.5,2.8)
+    -- (3.5,3.6)
+    -- (2,3.6)
+    -- (2,4.2);
+
+
+
+\draw[thick, myred]
+    (6.5, 4.2)
+    -- (10, 4.2)
+    -- (10, 2)
+    -- (6.5, 2)
+    -- (6.5, 4.2);
+
+\draw[thick, mypurple]
+    (6.5, 1.8)
+    -- (10, 1.8)
+    -- (10, -0.5)
+    -- (6.5, -0.5)
+    -- (6.5, 1.8);
+% Red X marks
+\foreach \x/\y in {
+    2.3/3.9,
+    3.8/3.1,
+    5.3/2.3
+}{
+    \draw[red, thick] (\x-0.15,\y-0.15) -- (\x+0.15,\y+0.15);
+    \draw[red, thick] (\x-0.15,\y+0.15) -- (\x+0.15,\y-0.15);
+}
+
+% "Nonzero" label
+\node[red] at (3.5,6) {Nonzero};
+
+% Red arrows
+\draw[red, ->, thick] (3.1,5.8) to[out=-150,in=90] (2.3,4.25);
+\draw[red, ->, thick] (3.6,5.8) to[out=-90,in=90] (3.8,3.3);
+\draw[red, ->, thick] (4.1,5.8) to[out=-90,in=90] (5.3,2.5);
+
+\node[myblue] at (0.25,1.2) {$i$};
+\draw[myblue, ->, thick](0.75, 1.2) -- (1.5, 1.2);
+\node[myblue] at (5.5, 5.75) {$j$};
+\draw[myblue, ->, thick](5.5, 5.25) -- (5.5,4.5);
+
+\node[mypurple] at (9, 0) {next};
+
+\end{tikzpicture}
+

--- a/Notes/algorithms.tex
+++ b/Notes/algorithms.tex
@@ -214,7 +214,7 @@ which shows that $T(n) >= n! = 2^{\Omega({n \log n})}$ which is \emph{exponentia
 
 \begin{figure}
   \centering
-  \includegraphics[height=5cm]{figures/DeterminantAlgoSlow.jpg}
+	\input{./TIKZ/determinant-algo-slow.tikz}
   \caption{An example of the recursion tree of the algorithm from Example~\ref{exe:det}. The tree corresponds to the run of the algorithm on input $\protect\smat{         3 & 7 & 5 \\ 2&9&8 \\ 1 & 3 & 3  }.$
 } 
 \end{figure}
@@ -295,7 +295,7 @@ with a non-singular $Q ∈ ℚ^{m × m}$. On the other hand we have the followin
 
 \begin{figure}  
    \centering
-  \includegraphics[height=5cm]{figures/Echelon.jpg}
+  	\input{./TIKZ/echelon-gaussian-elimination.tikz}   
   \caption{Gaussian elimination: The matrix $A'$ before  the $i$-th iteration of the while loop. \label{fig:9}}
 \end{figure}
 


### PR DESCRIPTION
This PR replaces the previous screenshots in chapter 6, figure 6.1 and 6.2. The content of both figures remains unchanged; only the representation format has been updated.
### New figure 6.1:
<img width="562" height="247" alt="2026-04-14_2" src="https://github.com/user-attachments/assets/0b4b66c5-bdae-408d-835f-2c5b968d70f9" />

### New figure 6.2
<img width="318" height="195" alt="2026-04-14_3" src="https://github.com/user-attachments/assets/395367de-2f28-42cd-acb3-bcd57550eac9" />
